### PR TITLE
rename click lib

### DIFF
--- a/cerberus/scripts/commands/dns/cmd.py
+++ b/cerberus/scripts/commands/dns/cmd.py
@@ -2,7 +2,7 @@
 import os
 import json
 import click
-from click_alias import ClickAliasedGroup
+from click_aliases import ClickAliasedGroup
 
 from cerberus.scripts.config import ConfigFileProcessor
 from cerberus.scripts.utils import (

--- a/cerberus/scripts/commands/ipam/cmd.py
+++ b/cerberus/scripts/commands/ipam/cmd.py
@@ -1,6 +1,6 @@
 
 import click
-from click_alias import ClickAliasedGroup
+from click_aliases import ClickAliasedGroup
 
 from cerberus.phpipam import errors as phpipam_err
 from cerberus.scripts.config import ConfigFileProcessor

--- a/cerberus/scripts/commands/vm/cmd.py
+++ b/cerberus/scripts/commands/vm/cmd.py
@@ -2,7 +2,7 @@
 
 import time
 import click
-from click_alias import ClickAliasedGroup
+from click_aliases import ClickAliasedGroup
 
 from cerberus.scripts.utils import (
     prompt_y_n_question,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'click', 
         'click-configfile', 
-        'click-alias',
+        'click-aliases',
         'pyvmomi', 
         'dnspython', 
         'requests'


### PR DESCRIPTION
since the click-alias is renamed to click-aliases it will caused error when we try to build the Cerberus suites.

```
Searching for click-alias
Reading https://pypi.org/simple/click-alias/
Couldn't find index page for 'click-alias' (maybe misspelled?)
Scanning index of all packages (this may take a while)
Reading https://pypi.org/simple/
No local packages or working download links found for click-alias
error: Could not find suitable distribution for Requirement.parse('click-alias')
```